### PR TITLE
Extract the environment name from conda file

### DIFF
--- a/zsh-activate-py-environment.py
+++ b/zsh-activate-py-environment.py
@@ -126,7 +126,7 @@ def unlink():
             remove(file)
     else:
         __print_information(
-            f"No file found that explicitely links this directory, looked for: {', '.join(LINKED_ENV_FILES)}"
+            f"No file found that explicitly links this directory, looked for: {', '.join(LINKED_ENV_FILES)}"
         )
 
 
@@ -218,7 +218,7 @@ def __check_dependencies(command):
     if which(command):
         return True
     else:
-        __print_information(f"Necessary dependency '{command}' not installed, omiting this!")
+        __print_information(f"Necessary dependency '{command}' not installed, omitting this!")
         return False
 
 

--- a/zsh-activate-py-environment.py
+++ b/zsh-activate-py-environment.py
@@ -156,7 +156,7 @@ def __find_nearest_environment_file(
     for environment_files_list in [TYPE_TO_FILES[type] for type in priority]:
         for environment_file in environment_files_list:
             if environment_file in directory_content:
-                return FILE_TO_TYPE[environment_file], environment
+                return FILE_TO_TYPE[environment_file], join(directory, environment_file)
 
     parent_directory, not_root_directory = split(directory)
     if not_root_directory:
@@ -172,7 +172,7 @@ def __parse_conda_environment_file(environment_file):
 
     try:
         with open(environment_file, "r") as file:
-            env = yaml.safe_load(stream)
+            env = yaml.safe_load(file)
             return env.get('name', environment_file)
     except:
         raise Exception(

--- a/zsh-activate-py-environment.py
+++ b/zsh-activate-py-environment.py
@@ -156,13 +156,7 @@ def __find_nearest_environment_file(
     for environment_files_list in [TYPE_TO_FILES[type] for type in priority]:
         for environment_file in environment_files_list:
             if environment_file in directory_content:
-                type = FILE_TO_TYPE[environment_file]
-                if type == CONDA_TYPE:
-                    environment_name = join(directory, environment_file)
-                    with open(environment_file, "r") as stream:
-                        env = yaml.safe_load(stream)
-                            
-                    return type, environment
+                return FILE_TO_TYPE[environment_file], environment
 
     parent_directory, not_root_directory = split(directory)
     if not_root_directory:

--- a/zsh-activate-py-environment.py
+++ b/zsh-activate-py-environment.py
@@ -21,7 +21,7 @@ SUPPORTED_ENVIRONMENT_TYPES = [CONDA_TYPE, VENV_TYPE, POETRY_TYPE]
 LINKED_ENV_FILES = [".linked_env"]
 POETRY_FILES = ["poetry.lock"]
 VENV_FILES = ["venv", ".venv"]
-CONDA_FILES = ["environment.yaml"]
+CONDA_FILES = ["environment.yaml", "environment.yml"]
 
 TYPE_TO_FILES = {
     LINKED_TYPE: LINKED_ENV_FILES,

--- a/zsh-activate-py-environment.py
+++ b/zsh-activate-py-environment.py
@@ -241,8 +241,8 @@ def __handle_environment_file(type, environment_file_or_name):
 
     elif type == CONDA_TYPE:
         if __check_dependencies(CONDA_TYPE):
-             environment_path_or_name = __parse_conda_environment_file(
-                 environment_file_or_name
+            environment_path_or_name = __parse_conda_environment_file(
+                environment_file_or_name
             )
             __return_command(f"conda activate {environment_path_or_name}")
             __print_activation_message(type)


### PR DESCRIPTION
Also prioritize conda ahead poetry (in case they are used together) and support file called environment.yml (with `yml` suffix instead of `yaml`).

I'm assuming that poetry would only be used to manage python dependencies while conda might be used as the overarching environment manager.  My use case involves having poetry mange the requirements.txt file but conda manage the development environment as a whole (with a call to `pip: [ "-r requirements.txt" ]`).