### PR TITLE
Add `"pyproject.toml"` to `POETRY_FILES`

### DIFF
--- a/zsh-activate-py-environment.py
+++ b/zsh-activate-py-environment.py
@@ -25,7 +25,7 @@ LINKED_TYPE = "linked"
 SUPPORTED_ENVIRONMENT_TYPES = [CONDA_TYPE, VENV_TYPE, POETRY_TYPE]
 
 LINKED_ENV_FILES = [".linked_env"]
-POETRY_FILES = ["poetry.lock"]
+POETRY_FILES = ["poetry.lock", "pyproject.toml"]
 VENV_FILES = ["venv", ".venv"]
 CONDA_FILES = ["environment.yaml", "environment.yml"]
 


### PR DESCRIPTION
When entering in a directory without `poetry.lock` but with `pyproject.toml`, `zsh-activate-py-environment` didn't create a new Poetry Python environment as `pyproject.toml` was not listed as a Poetry environment file. This PR suggest adding it so that `zsh-activate-py-environment` can automagically instantiate a new Poetry environment :)